### PR TITLE
Added configuration to readme and Auth0.plist.example file

### DIFF
--- a/00-Login/README.md
+++ b/00-Login/README.md
@@ -28,6 +28,21 @@ Then open the `signinwithapple.xcworkspace' workspace in XCode 11.
 
 1. You will need to modify the the `Bundle Identifier` to match your own app identifier that has been configured for SIWA in the Apple Developer Portal.
 
+### Add Auth0 configuration
+
+Copy the `Auth0.plist.example` file to a file called `Auth0.plist`, and populate the values with your Auth0 app domain and client ID:
+
+```xml
+<plist version="1.0">
+<dict>
+    <key>Domain</key>
+    <string>{DOMAIN}</string>
+    <key>ClientId</key>
+    <string>{CLIENT_ID}</string>
+</dict>
+</plist>
+```
+
 ## Apple References
 
 - [Adding the Sign In with Apple Flow to Your App](https://developer.apple.com/documentation/authenticationservices/adding_the_sign_in_with_apple_flow_to_your_app)

--- a/00-Login/signinwithapple.xcodeproj/project.pbxproj
+++ b/00-Login/signinwithapple.xcodeproj/project.pbxproj
@@ -15,8 +15,8 @@
 		5BDA328A22D5DAFC0040307B /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5BDA328822D5DAFC0040307B /* Main.storyboard */; };
 		5BDA328C22D5DAFF0040307B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5BDA328B22D5DAFF0040307B /* Assets.xcassets */; };
 		5BDA328F22D5DAFF0040307B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5BDA328D22D5DAFF0040307B /* LaunchScreen.storyboard */; };
-		5BF9E1E023211F5F006777B3 /* Auth0.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5BF9E1DF23211F5F006777B3 /* Auth0.plist */; };
 		AACE635223311DBA00C9EC59 /* values.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACE635123311DBA00C9EC59 /* values.swift */; };
+		AAD4B1272344AEA5002E9DE2 /* Auth0.plist in Resources */ = {isa = PBXBuildFile; fileRef = AAD4B1262344AEA5002E9DE2 /* Auth0.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -32,8 +32,8 @@
 		5BDA329022D5DAFF0040307B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5BDA329622D5ED080040307B /* signinwithapple.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = signinwithapple.entitlements; sourceTree = "<group>"; };
 		5BF9E1DE231FC41F006777B3 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = SOURCE_ROOT; };
-		5BF9E1DF23211F5F006777B3 /* Auth0.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Auth0.plist; sourceTree = SOURCE_ROOT; };
 		AACE635123311DBA00C9EC59 /* values.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = values.swift; sourceTree = "<group>"; };
+		AAD4B1262344AEA5002E9DE2 /* Auth0.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Auth0.plist; sourceTree = "<group>"; };
 		ABC9601637C6E1891F97B7E5 /* Pods-signinwithapple.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-signinwithapple.debug.xcconfig"; path = "Target Support Files/Pods-signinwithapple/Pods-signinwithapple.debug.xcconfig"; sourceTree = "<group>"; };
 		F05C1EF788EBD48541B950E6 /* Pods-signinwithapple.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-signinwithapple.release.xcconfig"; path = "Target Support Files/Pods-signinwithapple/Pods-signinwithapple.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -81,7 +81,7 @@
 		5BDA328122D5DAFC0040307B /* signinwithapple */ = {
 			isa = PBXGroup;
 			children = (
-				5BF9E1DF23211F5F006777B3 /* Auth0.plist */,
+				AAD4B1262344AEA5002E9DE2 /* Auth0.plist */,
 				5BF9E1DE231FC41F006777B3 /* README.md */,
 				5BDA329622D5ED080040307B /* signinwithapple.entitlements */,
 				5BDA328222D5DAFC0040307B /* AppDelegate.swift */,
@@ -168,7 +168,7 @@
 				5BDA328F22D5DAFF0040307B /* LaunchScreen.storyboard in Resources */,
 				5BDA328C22D5DAFF0040307B /* Assets.xcassets in Resources */,
 				5BDA328A22D5DAFC0040307B /* Main.storyboard in Resources */,
-				5BF9E1E023211F5F006777B3 /* Auth0.plist in Resources */,
+				AAD4B1272344AEA5002E9DE2 /* Auth0.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -372,7 +372,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = signinwithapple/signinwithapple.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
@@ -396,7 +396,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = signinwithapple/signinwithapple.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";

--- a/00-Login/signinwithapple/Auth0.plist.example
+++ b/00-Login/signinwithapple/Auth0.plist.example
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Domain</key>
+	<string>{DOMAIN}</string>
+	<key>ClientId</key>
+	<string>{CLIENT_ID}</string>
+</dict>
+</plist>


### PR DESCRIPTION
This fills in a gap in our readme file which demonstrates how to use the example config file to specify values for the Auth0 app.

Also moved the plist file reference into the `signinwithapple` directory, consistent with the other Swift sample.

**Ref:** https://github.com/auth0-samples/auth0-ios-swift-siwa-samples/pull/3