### PR TITLE
Updated CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @cocojoe @stevehobbsdev
+*   @auth0-samples/dx-sdks-approver


### PR DESCRIPTION
### Changes

- Set `@auth0-samples/dx-sdks-approver` as the code owner for PR reviews